### PR TITLE
Feature to exclude routes and methods. Cache response and storage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import lcache from 'fastify-lcache';
 
 const app = fastify();
 app.register(lcache, {
-  ttl: 10, // set cached data lifetime to 10 minutes
+  ttlInMinutes: 10, // set cached data lifetime to 10 minutes
 });
 
 app.after(() => {
@@ -59,8 +59,12 @@ axios.get(url);
 
 ```js
 {
-  ttl?: 5,
+  ttlInMinutes?: 5,
   storageType?: 'Map',
+  statusesToCache?: [200],
+  methodsToCache?: ['GET'],
+  disableCache?: false;
+  excludeRoutes?: undefined;
 }
 ```
 
@@ -68,12 +72,18 @@ axios.get(url);
 
 ```js
 // app.lcache available inside your app
-// you can specify data type: app.lcache.get<{ name: string }>('person')
+// you can specify payload data type: app.lcache.get<{ name: string }>('person')
+
+interface CachedResponse<T> {
+  payload: T;
+  headers?: { [key: string]: string | number | string[]; };
+  statusCode?: number;
+}
 
 interface IStorage {
-  get<T>(key: string): T; // Get cached data
+  get<T>(key: string): CachedResponse<T>; // Get cached data
 
-  set<T>(key: string, value: T): void; // Set data to cache
+  set<T>(key: string, value: CachedResponse<T>): void; // Set data to cache
 
   has(key: string): boolean; // Check if data exists in cache
 

--- a/__tests__/lcache.test.ts
+++ b/__tests__/lcache.test.ts
@@ -17,6 +17,10 @@ const getSimpleApp = (excludeRoutes?: string[], statusesToCache = [200]) => {
       reply.send('pong');
     });
 
+    app.get('/json', async (_req, reply) => {
+      reply.send({ hello: 'world' });
+    });
+
     app.post('/post', async (req: any, reply) => {
       reply.status(201);
       reply.send(req.body.data);
@@ -63,6 +67,21 @@ describe('cache', () => {
     expect(res2.body).toBe('pong');
     expect(spy).toHaveBeenCalled();
   });
+
+  test('Cache should return same headers as the original request', async () => {
+    const spy = jest.spyOn(app.lcache, 'get');
+    const getJson = async () => app.inject({
+      method: 'GET',
+      path: '/json',
+    });
+
+    const res1 = await getJson();
+    const res2 = await getJson();
+
+    expect(res2.headers['content-type']).toBe(res1.headers['content-type']);
+    expect(spy).toHaveBeenCalled();
+  });
+
 });
 
 describe('Caching with custom options', () => {

--- a/__tests__/lcache.test.ts
+++ b/__tests__/lcache.test.ts
@@ -21,6 +21,7 @@ const getSimpleApp = (excludeRoutes?: string[], statusesToCache = [200]) => {
       reply.send({ hello: 'world' });
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any  
     app.post('/post', async (req: any, reply) => {
       reply.status(201);
       reply.send(req.body.data);
@@ -30,6 +31,7 @@ const getSimpleApp = (excludeRoutes?: string[], statusesToCache = [200]) => {
       setTimeout(() =>  reply.send(Date.now()), Math.random() * 100)
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     app.put('/put', async (req: any, reply) => {
       reply.status(201).send(req.body.data);
     });

--- a/__tests__/lcache.test.ts
+++ b/__tests__/lcache.test.ts
@@ -2,19 +2,34 @@ import '../lib/types/fastify';
 import fastify, { FastifyInstance } from 'fastify';
 import lcache from '../lib/lcache';
 
-const getSimpleApp = () => {
-  const port = 3333;
-  const address = '0.0.0.0';
+const getSimpleApp = (excludeRoutes?: string[], statusesToCache = [200]) => {
   const app = fastify();
-  const lcacheOptions = { ttl: 2 };
+  const lcacheOptions = {
+    ttlInMinutes: 2,
+    excludeRoutes,
+    statusesToCache
+  };
+
   app.register(lcache, lcacheOptions);
 
   app.after(() => {
     app.get('/ping', async (_req, reply) => {
       reply.send('pong');
     });
+
+    app.post('/post', async (req: any, reply) => {
+      reply.status(201);
+      reply.send(req.body.data);
+    });
+
+    app.get('/date', async (_req, reply) => {
+      setTimeout(() =>  reply.send(Date.now()), Math.random() * 100)
+    });
+
+    app.put('/put', async (req: any, reply) => {
+      reply.status(201).send(req.body.data);
+    });
   });
-  app.listen(port, address);
 
   return app;
 };
@@ -49,3 +64,69 @@ describe('cache', () => {
     expect(spy).toHaveBeenCalled();
   });
 });
+
+describe('Caching with custom options', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await getSimpleApp(['/date'], [200,201]);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test('POST method should not be cached', async () => {
+    const res1 = await app.inject({
+      method: 'POST',
+      path: '/post',
+      payload: {
+        data: 'first-payload',
+      },
+    });
+
+    const res2 = await app.inject({
+      method: 'POST',
+      path: '/post',
+      payload: {
+        data: 'second-payload',
+      },
+    });
+
+    expect(res1.body).not.toBe(res2.body);
+  });
+
+  test('Excluded routes should not be cached', async () => {
+    const res1 = await app.inject({
+      method: 'GET',
+      path: '/date',
+    });
+
+    const res2 = await app.inject({
+      method: 'GET',
+      path: '/date',
+    });
+
+    expect(res1.body).not.toBe(res2.body);
+  })
+
+  test('Method PUT should not be cached when only status code is 201', async () => {
+    const res1 = await app.inject({
+      method: 'PUT',
+      path: '/put',
+      payload: {
+        data: '456'
+      }
+    });
+
+    const res2 = await app.inject({
+      method: 'PUT',
+      path: '/put',
+      payload: {
+        data: '123'
+      }
+    });
+
+    expect(res1.body).not.toBe(res2.body);
+  })
+})

--- a/__tests__/lcache.test.ts
+++ b/__tests__/lcache.test.ts
@@ -7,7 +7,7 @@ const getSimpleApp = (excludeRoutes?: string[], statusesToCache = [200]) => {
   const lcacheOptions = {
     ttlInMinutes: 2,
     excludeRoutes,
-    statusesToCache
+    statusesToCache,
   };
 
   app.register(lcache, lcacheOptions);
@@ -21,14 +21,14 @@ const getSimpleApp = (excludeRoutes?: string[], statusesToCache = [200]) => {
       reply.send({ hello: 'world' });
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any  
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     app.post('/post', async (req: any, reply) => {
       reply.status(201);
       reply.send(req.body.data);
     });
 
     app.get('/date', async (_req, reply) => {
-      setTimeout(() =>  reply.send(Date.now()), Math.random() * 100)
+      setTimeout(() => reply.send(Date.now()), Math.random() * 100);
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -83,14 +83,13 @@ describe('cache', () => {
     expect(res2.headers['content-type']).toBe(res1.headers['content-type']);
     expect(spy).toHaveBeenCalled();
   });
-
 });
 
 describe('Caching with custom options', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
-    app = await getSimpleApp(['/date'], [200,201]);
+    app = await getSimpleApp(['/date'], [200, 201]);
   });
 
   afterEach(async () => {
@@ -129,25 +128,25 @@ describe('Caching with custom options', () => {
     });
 
     expect(res1.body).not.toBe(res2.body);
-  })
+  });
 
   test('Method PUT should not be cached when only status code is 201', async () => {
     const res1 = await app.inject({
       method: 'PUT',
       path: '/put',
       payload: {
-        data: '456'
-      }
+        data: '456',
+      },
     });
 
     const res2 = await app.inject({
       method: 'PUT',
       path: '/put',
       payload: {
-        data: '123'
-      }
+        data: '123',
+      },
     });
 
     expect(res1.body).not.toBe(res2.body);
-  })
-})
+  });
+});

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -19,14 +19,14 @@ export const formatOptions = (opts: ICacheOptions): ICachePluginOptions => ({
 export const shouldBeCached = (
   opts: ICachePluginOptions,
   request: FastifyRequest,
-  statusCode: number
+  statusCode: number,
 ): boolean => {
   const { methodsToCache, statusesToCache, excludeRoutes } = opts;
   const { routerPath, method } = request;
 
   return (
-    methodsToCache.has(method as RequestMethod) &&
-    statusesToCache.has(statusCode) &&
-    !excludeRoutes.has(routerPath)
+    methodsToCache.has(method as RequestMethod)
+    && statusesToCache.has(statusCode)
+    && !excludeRoutes.has(routerPath)
   );
 };

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,9 +1,32 @@
 /* eslint-disable import/prefer-default-export */
-import type { ICacheOptions } from './types/lcache';
+import type { FastifyRequest } from 'fastify';
+import type {
+  RequestMethod,
+  ICacheOptions,
+  ICachePluginOptions,
+} from './types/lcache';
 
 const getMilliseconds = (min: number): number => min * 60000;
 
-export const formatOptions = (opts: ICacheOptions): ICacheOptions => ({
+export const formatOptions = (opts: ICacheOptions): ICachePluginOptions => ({
   ...opts,
-  ttl: getMilliseconds(opts.ttl),
+  methodsToCache: new Set(opts.methodsToCache),
+  statusesToCache: new Set(opts.statusesToCache),
+  excludeRoutes: new Set(opts.excludeRoutes?.map((r) => r.trim())),
+  ttl: getMilliseconds(opts.ttlInMinutes),
 });
+
+export const shouldBeCached = (
+  opts: ICachePluginOptions,
+  request: FastifyRequest,
+  statusCode: number
+): boolean => {
+  const { methodsToCache, statusesToCache, excludeRoutes } = opts;
+  const { routerPath, method } = request;
+
+  return (
+    methodsToCache.has(method as RequestMethod) &&
+    statusesToCache.has(statusCode) &&
+    !excludeRoutes.has(routerPath)
+  );
+};

--- a/lib/lcache.ts
+++ b/lib/lcache.ts
@@ -18,8 +18,7 @@ const cache: FastifyPluginCallback<ICacheOptions> = (
 ) => {
   if (opts.disableCache) {
     _next();
-
-    return false;
+    return;
   }
 
   const pluginOpts = formatOptions({ ...defaultOpts, ...opts });
@@ -33,8 +32,8 @@ const cache: FastifyPluginCallback<ICacheOptions> = (
     const requestId = url + method;
 
     if (
-      !storage.has(requestId) &&
-      shouldBeCached(pluginOpts, request, reply.statusCode)
+      !storage.has(requestId)
+      && shouldBeCached(pluginOpts, request, reply.statusCode)
     ) {
       storage.set(requestId, {
         payload,

--- a/lib/lcache.ts
+++ b/lib/lcache.ts
@@ -17,7 +17,9 @@ const cache: FastifyPluginCallback<ICacheOptions> = (
   _next,
 ) => {
   if (opts.disableCache) {
-    return _next();
+    _next();
+
+    return false;
   }
 
   const pluginOpts = formatOptions({ ...defaultOpts, ...opts });

--- a/lib/storages/Map.ts
+++ b/lib/storages/Map.ts
@@ -3,6 +3,7 @@ import {
   SrcMeta,
   IStorage,
   IStorageOptions,
+  CachedResponse,
 } from '../types/storage';
 
 export default class Storage implements IStorage {
@@ -36,14 +37,14 @@ export default class Storage implements IStorage {
   /**
    * Get cached data
    */
-  public get<T>(key: string): T {
+  public get<T>(key: string): CachedResponse<T> {
     return this.src.get(key);
   }
 
   /**
    * Set data to cache
    */
-  public set<T>(key: string, value: T): void {
+  public set<T>(key: string, value: CachedResponse<T>): void {
     this.src.set(key, value);
     this.srcMeta.set(key, { updatedAt: Date.now() });
   }

--- a/lib/storages/Map.ts
+++ b/lib/storages/Map.ts
@@ -1,5 +1,8 @@
 import {
-  Src, SrcMeta, IStorageOptions, IStorage,
+  Src,
+  SrcMeta,
+  IStorage,
+  IStorageOptions,
 } from '../types/storage';
 
 export default class Storage implements IStorage {

--- a/lib/storages/Map.ts
+++ b/lib/storages/Map.ts
@@ -17,13 +17,12 @@ export default class Storage implements IStorage {
   private initCacheCleaner() {
     this.intervalId = setInterval(() => {
       this.srcMeta.forEach(({ updatedAt }, key) => {
-        const date = new Date();
-        const isTtlOutdate = date.getTime() - updatedAt.getTime() > this.options.ttl;
+        const isTtlOutdate = Date.now() - updatedAt > this.options.ttl;
         if (isTtlOutdate) {
           this.src.delete(key);
         }
       });
-    }, this.options.ttl);
+    }, 15000);
   }
 
   /**
@@ -46,7 +45,7 @@ export default class Storage implements IStorage {
    */
   public set<T>(key: string, value: T): void {
     this.src.set(key, value);
-    this.srcMeta.set(key, { updatedAt: new Date() });
+    this.srcMeta.set(key, { updatedAt: Date.now() });
   }
 
   /**

--- a/lib/types/lcache.d.ts
+++ b/lib/types/lcache.d.ts
@@ -1,12 +1,30 @@
-/// <reference types="node" />
+/// <reference types='node' />
 import type { IStorageOptions } from './storage';
 import { FastifyPluginCallback } from 'fastify';
 
-export type StorageType = 'Map'
+export type StorageType = 'Map';
 
-export interface ICacheOptions extends IStorageOptions {
-  storageType?: StorageType
+export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+export interface ICachePluginOptions extends IStorageOptions {
+  storageType?: StorageType;
+  methodsToCache?: Set<RequestMethod>;
+  statusesToCache?: Set<number>;
+  excludeRoutes?: Set<string>;
 }
 
-declare const _default: FastifyPluginCallback<ICacheOptions, import('http').Server>;
+export interface ICacheOptions<> {
+  disableCache?: boolean;
+  ttlInMinutes?: number;
+  storageType?: StorageType;
+  methodsToCache?: RequestMethod[];
+  statusesToCache?: number[];
+  excludeRoutes?: string[];
+}
+
+declare const _default: FastifyPluginCallback<
+  ICacheOptions,
+  import('http').Server
+>;
+
 export default _default;

--- a/lib/types/lcache.d.ts
+++ b/lib/types/lcache.d.ts
@@ -1,6 +1,6 @@
-/// <reference types='node' />
-import type { IStorageOptions } from './storage';
+/// <reference types="node" />
 import { FastifyPluginCallback } from 'fastify';
+import type { IStorageOptions } from './storage';
 
 export type StorageType = 'Map';
 

--- a/lib/types/storage.d.ts
+++ b/lib/types/storage.d.ts
@@ -7,7 +7,7 @@ export type Src = Map<string, any>;
 export type SrcMeta = Map<
   string,
   {
-    updatedAt: Date;
+    updatedAt: number;
   }
 >;
 

--- a/lib/types/storage.d.ts
+++ b/lib/types/storage.d.ts
@@ -2,8 +2,15 @@
 export interface IStorageOptions {
   ttl?: number;
 }
+
+export interface CachedResponse<T> {
+  payload: T;
+  headers?: { [key: string]: string | number | string[]; };
+  statusCode?: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Src = Map<string, any>;
+export type Src = Map<string, CachedResponse<any>>;
 export type SrcMeta = Map<
   string,
   {
@@ -12,9 +19,9 @@ export type SrcMeta = Map<
 >;
 
 export interface IStorage {
-  get<T>(key: string): T;
+  get<T>(key: string): CachedResponse<T>;
 
-  set<T>(key: string, value: T): void;
+  set<T>(key: string, value: CachedResponse<T>): void;
 
   has(key: string): boolean;
 


### PR DESCRIPTION
This version includes the following updates and improvements:
 - It is possible to exclude specific routes from caching;
 - Fixed a bug, when 404,500,201 and other statuses had been cached. It is still possible to specify them in config if needed.
 - Fixed a bug when cached response was sent with wrong headers, ex. 'text/plain' instead of 'application/json'.
 - Fixed a bug, when POST/PUT/DELETE requests responded from cache preventing to hit an actual handler to make an update. It is still possible to specify them explicitly in config if needed.
 - Fixed a bug, when cache did not clear after ttl. Clear job is now restarting every 15 sec.
 - Improved some variable names.
 - Added tests for the new features.
 - Updated Readme file.