### PR TITLE
Improve library unit test coverage

### DIFF
--- a/__tests__/helpers.unit.test.ts
+++ b/__tests__/helpers.unit.test.ts
@@ -1,0 +1,70 @@
+import * as helpers from "@/utils/helpers";
+
+describe("helpers", () => {
+  describe("wildcardToRegExp", () => {
+    it("should match wildcard patterns", () => {
+      const pattern = helpers.wildcardToRegExp("/api/ad*in");
+      expect(pattern.test("/api/admin")).toBe(true);
+      expect(pattern.test("/api/adin")).toBe(true);
+      expect(pattern.test("/api/adZZin")).toBe(true);
+      expect(pattern.test("/api/aDin/foo")).toBe(false);
+    });
+  });
+
+  describe("formatOptions and buildCacheKey", () => {
+    it("should trim routes and convert collections to Sets, and hash payload into key", () => {
+      const opts = helpers.formatOptions({
+        ttlInMinutes: 1,
+        disableCache: false,
+        statusesToCache: [200, 201],
+        methodsToCache: ["GET", "POST"],
+        excludeRoutes: [" /foo ", " /bar/*  "],
+        includeRoutes: [" /a ", " /b* "],
+      } as any);
+
+      expect(opts.ttlInMs).toBe(60_000);
+      expect(opts.methodsToCache.has("GET")).toBe(true);
+      expect(opts.statusesToCache.has(201)).toBe(true);
+      expect(opts.excludeRoutes).toEqual(["/foo", "/bar/*"]);
+      expect(Array.isArray(opts.includeRoutes)).toBe(true);
+
+      const key1 = helpers.buildCacheKey({
+        url: "/path",
+        method: "GET",
+        body: { a: 1 },
+        query: undefined,
+      } as any);
+      const key2 = helpers.buildCacheKey({
+        url: "/path",
+        method: "GET",
+        body: { a: 2 },
+        query: undefined,
+      } as any);
+      const key3 = helpers.buildCacheKey({
+        url: "/path",
+        method: "GET",
+        body: undefined,
+        query: { a: 1 },
+      } as any);
+
+      // same payload (although body vs query) produces same cache key
+      expect(key1).not.toEqual(key2);
+      expect(key1).toEqual(key3);
+      expect(key2).not.toEqual(key3);
+    });
+
+    it("should preserve '*' includeRoutes as wildcard", () => {
+      const opts = helpers.formatOptions({
+        ttlInMinutes: 1,
+        disableCache: false,
+        statusesToCache: [200],
+        methodsToCache: ["GET"],
+        excludeRoutes: [],
+        includeRoutes: "*",
+      } as any);
+
+      expect(opts.includeRoutes).toBe("*");
+    });
+  });
+});
+

--- a/__tests__/lightcache.unit.test.ts
+++ b/__tests__/lightcache.unit.test.ts
@@ -1,0 +1,32 @@
+import { LightCache } from "@/models/LightCache";
+import MapStorage from "@/models/MapStorage";
+
+describe("LightCache facade", () => {
+  it("destroy should prune all data immediately", () => {
+    const storage = new MapStorage({ ttlInMs: 60_000 });
+    const cache = new LightCache(storage);
+
+    const key = "key-to-destroy";
+    const value = { foo: "bar" };
+
+    cache.set(key, value);
+    expect(cache.has(key)).toBeTruthy();
+    expect(cache.get<typeof value>(key)).toEqual(value);
+
+    // destroy underlying storage via facade
+    cache.destroy();
+
+    expect(cache.has(key)).toBeFalsy();
+    expect(cache.get<typeof value>(key)).toBeUndefined();
+  });
+
+  it("get should return undefined for missing keys", () => {
+    const storage = new MapStorage({ ttlInMs: 60_000 });
+    const cache = new LightCache(storage);
+
+    expect(cache.get("missing-key")).toBeUndefined();
+
+    cache.destroy();
+  });
+});
+


### PR DESCRIPTION
Add unit tests for `LightCache.destroy` and helper functions to improve test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-2599bcfb-db68-439a-b230-0d442f510fb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2599bcfb-db68-439a-b230-0d442f510fb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

