### PR TITLE
chore: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "fastify-lcache",
+  "install": "npm ci"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for `fastify-lcache`.

`fastify-lcache` is a pure TypeScript Fastify plugin — there are no runtime services, databases, or secrets to manage. The environment therefore uses Cursor's default image (which provides Node 22) and a single idempotent `install` step.

```json
{
  "name": "fastify-lcache",
  "install": "npm ci"
}
```

## Validation

All commands run on the current VM (Node `v22.14.0`):

| Check | Result |
| --- | --- |
| `npm ci` | Installed 535 packages, `found 0 vulnerabilities` |
| `npm ci` (idempotence) | Passed a second time cleanly |
| `npm run build` (`tsc`) | Compiled with no errors |
| `npm run lint` (`eslint .`) | Clean, no warnings |
| `npm test` (jest) | 5 suites, 33 tests passed |
| End-to-end plugin caching | Registered the built plugin on a real Fastify app; a route returning a fresh timestamp/random value returned an identical cached payload on the second request, `lcache.has(key)` confirmed the entry, and `lcache.reset()` produced a fresh payload |

No application code was changed; only the environment config was added.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60969032-4d61-47f1-aab3-a6de6b2b3c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60969032-4d61-47f1-aab3-a6de6b2b3c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

