### PR TITLE
ci: publish to npm from auto-release after creating a release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -27,15 +27,37 @@ jobs:
           echo "Package version: $VERSION"
 
       # No automatic version bumps. Create a GitHub release only when
-      # v{version} does not already exist (covers intentional bumps and
-      # catch-up when package.json was bumped without a release).
+      # v{version} does not already exist.
+      #
+      # NOTE: Releases created with GITHUB_TOKEN do NOT trigger other
+      # workflows' `on: release` hooks (GitHub recursion guard). So npm
+      # publish must happen in this job when we create the release.
       - name: Create release if missing
+        id: release
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           if gh release view "v${VERSION}" 2>/dev/null; then
             echo "Release v${VERSION} already exists, skipping"
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           gh release create "v${VERSION}" --generate-notes --target "${{ github.sha }}"
+          echo "created=true" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        if: steps.release.outputs.created == 'true'
+        with:
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        if: steps.release.outputs.created == 'true'
+        run: |
+          npm ci
+          npm test
+          npm run build
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,8 +1,12 @@
 name: Publish package to npmjs
 
 on:
+  # Fires for releases created in the GitHub UI / with a PAT.
+  # Does NOT fire for releases created by GITHUB_TOKEN in another workflow.
   release:
     types: [published]
+  # Manual retry / catch-up when auto-release already created the GitHub release
+  workflow_dispatch:
 
 jobs:
   ci:
@@ -12,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
GitHub does not start `on: release` workflows when the release was created with GITHUB_TOKEN. Publish directly in auto-release when a release is new, and add workflow_dispatch on the npm workflow for manual catch-up.